### PR TITLE
add sample ltc config for chaincfg

### DIFF
--- a/chaincfg/sample-ltc.conf
+++ b/chaincfg/sample-ltc.conf
@@ -1,0 +1,391 @@
+[ChainParams]
+  [ChainParams.MainNetParams]
+    Name = "mainnet"
+    Net = 3652501241
+    DefaultPort = "9333"
+    GenesisHash = [226, 191, 4, 126, 126, 90, 25, 26, 164, 239, 52, 211, 20, 151, 157, 201, 152, 110, 15, 25, 37, 30, 218, 186, 89, 64, 253, 31, 227, 101, 167, 18]
+    PowLimitBits = 504365055
+    BIP0034Height = 710000
+    BIP0065Height = 918684
+    BIP0066Height = 811879
+    CoinbaseMaturity = 100
+    SubsidyReductionInterval = 840000
+    TargetTimespan = 302400000000000
+    TargetTimePerBlock = 150000000000
+    RetargetAdjustmentFactor = 4
+    ReduceMinDifficulty = false
+    MinDiffReductionTime = 0
+    GenerateSupported = false
+    RuleChangeActivationThreshold = 6048
+    MinerConfirmationWindow = 8064
+    RelayNonStdTxs = false
+    Bech32HRPSegwit = "ltc"
+    PubKeyHashAddrID = 48
+    ScriptHashAddrID = 50
+    PrivateKeyID = 176
+    WitnessPubKeyHashAddrID = 6
+    WitnessScriptHashAddrID = 10
+    HDPrivateKeyID = [4, 136, 173, 228]
+    HDPublicKeyID = [4, 136, 178, 30]
+    HDCoinType = 2
+
+    [[ChainParams.MainNetParams.DNSSeeds]]
+      Host = "seed-a.litecoin.loshan.co.uk"
+      HasFiltering = true
+
+    [[ChainParams.MainNetParams.DNSSeeds]]
+      Host = "dnsseed.thrasher.io"
+      HasFiltering = true
+
+    [[ChainParams.MainNetParams.DNSSeeds]]
+      Host = "dnsseed.litecointools.com"
+      HasFiltering = false
+
+    [[ChainParams.MainNetParams.DNSSeeds]]
+      Host = "dnsseed.litecoinpool.org"
+      HasFiltering = false
+
+    [[ChainParams.MainNetParams.DNSSeeds]]
+      Host = "dnsseed.koin-project.com"
+      HasFiltering = false
+    [ChainParams.MainNetParams.GenesisBlock]
+      [ChainParams.MainNetParams.GenesisBlock.Header]
+        Version = 1
+        PrevBlock = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        MerkleRoot = [217, 206, 212, 237, 17, 48, 247, 183, 250, 173, 155, 226, 83, 35, 255, 175, 163, 50, 50, 161, 124, 62, 223, 108, 253, 151, 190, 230, 186, 251, 221, 151]
+        Timestamp = 2011-10-07T07:31:05Z
+        Bits = 504365040
+        Nonce = 2084524493
+
+      [[ChainParams.MainNetParams.GenesisBlock.Transactions]]
+        Version = 1
+        LockTime = 0
+
+        [[ChainParams.MainNetParams.GenesisBlock.Transactions.TxIn]]
+          SignatureScript = [4, 255, 255, 0, 29, 1, 4, 64, 78, 89, 32, 84, 105, 109, 101, 115, 32, 48, 53, 47, 79, 99, 116, 47, 50, 48, 49, 49, 32, 83, 116, 101, 118, 101, 32, 74, 111, 98, 115, 44, 32, 65, 112, 112, 108, 101, 226, 128, 153, 115, 32, 86, 105, 115, 105, 111, 110, 97, 114, 121, 44, 32, 68, 105, 101, 115, 32, 97, 116, 32, 53, 54]
+          Sequence = 4294967295
+          [ChainParams.MainNetParams.GenesisBlock.Transactions.TxIn.PreviousOutPoint]
+            Hash = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            Index = 4294967295
+
+        [[ChainParams.MainNetParams.GenesisBlock.Transactions.TxOut]]
+          Value = 5000000000
+          PkScript = [65, 4, 1, 132, 113, 15, 166, 137, 173, 80, 35, 105, 12, 128, 243, 164, 156, 143, 19, 248, 212, 91, 140, 133, 127, 188, 188, 139, 196, 168, 228, 211, 235, 75, 16, 244, 212, 96, 79, 160, 141, 206, 96, 26, 175, 15, 71, 2, 22, 254, 27, 81, 133, 11, 74, 207, 33, 177, 121, 196, 80, 112, 172, 123, 3, 169, 172]
+    PowLimit = "110427836236357352041769395878404723568785424659630784333489133269811200"
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 1500
+      Hash = [103, 41, 154, 181, 162, 2, 68, 175, 201, 94, 131, 118, 212, 139, 95, 228, 84, 90, 208, 85, 167, 7, 167, 207, 136, 210, 93, 149, 101, 41, 26, 132]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 4032
+      Hash = [70, 8, 207, 217, 227, 215, 95, 150, 135, 169, 53, 253, 106, 226, 128, 91, 114, 3, 53, 206, 5, 89, 94, 240, 14, 252, 152, 113, 66, 14, 233, 156]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 8064
+      Hash = [112, 13, 67, 148, 166, 125, 152, 179, 252, 41, 183, 240, 239, 238, 185, 186, 164, 184, 64, 12, 21, 31, 101, 16, 242, 144, 81, 252, 83, 67, 152, 235]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 16128
+      Hash = [61, 21, 205, 28, 42, 225, 3, 236, 75, 122, 205, 157, 77, 29, 220, 111, 182, 108, 14, 155, 29, 159, 128, 175, 166, 249, 183, 89, 24, 223, 46, 96]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 23420
+      Hash = [7, 181, 1, 81, 11, 206, 143, 151, 78, 135, 236, 48, 37, 143, 165, 125, 84, 254, 169, 195, 10, 169, 178, 210, 11, 253, 26, 168, 156, 223, 15, 216]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 50000
+      Hash = [166, 32, 122, 208, 113, 62, 43, 43, 136, 50, 58, 79, 219, 42, 103, 39, 193, 25, 4, 204, 45, 1, 165, 117, 240, 104, 155, 2, 235, 55, 220, 105]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 80000
+      Hash = [10, 233, 178, 205, 46, 24, 103, 72, 203, 190, 140, 106, 180, 32, 249, 168, 85, 153, 168, 100, 199, 73, 63, 80, 0, 163, 118, 246, 2, 124, 203, 79]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 120000
+      Hash = [49, 97, 172, 82, 53, 122, 106, 2, 27, 18, 231, 233, 206, 41, 142, 158, 200, 142, 130, 50, 95, 21, 240, 167, 218, 246, 5, 79, 146, 38, 157, 189]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 161500
+      Hash = [67, 255, 113, 132, 121, 247, 187, 141, 65, 184, 40, 59, 18, 145, 73, 2, 220, 28, 186, 119, 124, 34, 92, 247, 180, 75, 79, 71, 128, 152, 232, 219]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 179620
+      Hash = [9, 247, 185, 120, 43, 11, 165, 88, 131, 178, 220, 167, 233, 105, 250, 47, 190, 215, 15, 110, 68, 142, 209, 38, 4, 192, 10, 153, 92, 198, 217, 42]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 240000
+      Hash = [170, 136, 80, 85, 161, 62, 46, 171, 110, 78, 12, 89, 196, 57, 219, 115, 156, 76, 242, 54, 118, 238, 23, 162, 124, 21, 194, 180, 196, 209, 64, 113]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 383640
+      Hash = [100, 243, 198, 38, 241, 195, 150, 160, 144, 5, 125, 75, 233, 75, 163, 39, 81, 163, 16, 241, 179, 94, 198, 175, 91, 33, 169, 148, 240, 9, 104, 43]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 409004
+      Hash = [163, 8, 89, 53, 241, 180, 57, 207, 233, 119, 14, 220, 251, 103, 182, 130, 217, 116, 173, 149, 147, 29, 97, 8, 250, 241, 217, 99, 214, 24, 117, 72]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 456000
+      Hash = [4, 32, 55, 86, 36, 227, 27, 64, 125, 172, 1, 5, 164, 166, 76, 227, 151, 248, 34, 190, 6, 13, 147, 135, 212, 108, 54, 198, 28, 247, 52, 191]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 638902
+      Hash = [56, 79, 199, 174, 59, 197, 236, 92, 196, 156, 205, 61, 149, 252, 154, 129, 165, 243, 252, 117, 140, 154, 226, 141, 210, 99, 236, 232, 86, 134, 35, 21]
+
+    [[ChainParams.MainNetParams.Checkpoints]]
+      Height = 721000
+      Hash = [229, 64, 152, 154, 117, 138, 220, 65, 22, 116, 62, 230, 162, 53, 178, 234, 20, 183, 117, 157, 217, 59, 70, 226, 120, 148, 223, 225, 77, 123, 138, 25]
+
+    [[ChainParams.MainNetParams.Deployments]]
+      BitNumber = 28
+      StartTime = 1199145601
+      ExpireTime = 1230767999
+
+    [[ChainParams.MainNetParams.Deployments]]
+      BitNumber = 0
+      StartTime = 1485561600
+      ExpireTime = 1517356801
+
+    [[ChainParams.MainNetParams.Deployments]]
+      BitNumber = 1
+      StartTime = 1485561600
+      ExpireTime = 1517356801
+  [ChainParams.TestNet3Params]
+    Name = "testnet4"
+    Net = 4056470269
+    DefaultPort = "19335"
+    GenesisHash = [160, 41, 62, 78, 235, 61, 166, 230, 245, 111, 129, 237, 89, 95, 87, 136, 13, 26, 33, 86, 158, 19, 238, 253, 217, 81, 40, 75, 90, 98, 102, 73]
+    PowLimitBits = 504365055
+    BIP0034Height = 76
+    BIP0065Height = 76
+    BIP0066Height = 76
+    CoinbaseMaturity = 100
+    SubsidyReductionInterval = 840000
+    TargetTimespan = 302400000000000
+    TargetTimePerBlock = 150000000000
+    RetargetAdjustmentFactor = 4
+    ReduceMinDifficulty = true
+    MinDiffReductionTime = 300000000000
+    GenerateSupported = false
+    RuleChangeActivationThreshold = 1512
+    MinerConfirmationWindow = 2016
+    RelayNonStdTxs = true
+    Bech32HRPSegwit = "tltc"
+    PubKeyHashAddrID = 111
+    ScriptHashAddrID = 196
+    PrivateKeyID = 239
+    WitnessPubKeyHashAddrID = 82
+    WitnessScriptHashAddrID = 49
+    HDPrivateKeyID = [4, 53, 131, 148]
+    HDPublicKeyID = [4, 53, 135, 207]
+    HDCoinType = 1
+
+    [[ChainParams.TestNet3Params.DNSSeeds]]
+      Host = "testnet-seed.litecointools.com"
+      HasFiltering = false
+
+    [[ChainParams.TestNet3Params.DNSSeeds]]
+      Host = "seed-b.litecoin.loshan.co.uk"
+      HasFiltering = true
+
+    [[ChainParams.TestNet3Params.DNSSeeds]]
+      Host = "dnsseed-testnet.thrasher.io"
+      HasFiltering = true
+    [ChainParams.TestNet3Params.GenesisBlock]
+      [ChainParams.TestNet3Params.GenesisBlock.Header]
+        Version = 1
+        PrevBlock = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        MerkleRoot = [217, 206, 212, 237, 17, 48, 247, 183, 250, 173, 155, 226, 83, 35, 255, 175, 163, 50, 50, 161, 124, 62, 223, 108, 253, 151, 190, 230, 186, 251, 221, 151]
+        Timestamp = 2017-02-13T01:29:26Z
+        Bits = 504365040
+        Nonce = 293345
+
+      [[ChainParams.TestNet3Params.GenesisBlock.Transactions]]
+        Version = 1
+        LockTime = 0
+
+        [[ChainParams.TestNet3Params.GenesisBlock.Transactions.TxIn]]
+          SignatureScript = [4, 255, 255, 0, 29, 1, 4, 64, 78, 89, 32, 84, 105, 109, 101, 115, 32, 48, 53, 47, 79, 99, 116, 47, 50, 48, 49, 49, 32, 83, 116, 101, 118, 101, 32, 74, 111, 98, 115, 44, 32, 65, 112, 112, 108, 101, 226, 128, 153, 115, 32, 86, 105, 115, 105, 111, 110, 97, 114, 121, 44, 32, 68, 105, 101, 115, 32, 97, 116, 32, 53, 54]
+          Sequence = 4294967295
+          [ChainParams.TestNet3Params.GenesisBlock.Transactions.TxIn.PreviousOutPoint]
+            Hash = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            Index = 4294967295
+
+        [[ChainParams.TestNet3Params.GenesisBlock.Transactions.TxOut]]
+          Value = 5000000000
+          PkScript = [65, 4, 1, 132, 113, 15, 166, 137, 173, 80, 35, 105, 12, 128, 243, 164, 156, 143, 19, 248, 212, 91, 140, 133, 127, 188, 188, 139, 196, 168, 228, 211, 235, 75, 16, 244, 212, 96, 79, 160, 141, 206, 96, 26, 175, 15, 71, 2, 22, 254, 27, 81, 133, 11, 74, 207, 33, 177, 121, 196, 80, 112, 172, 123, 3, 169, 172]
+    PowLimit = "110427836236357352041769395878404723568785424659630784333489133269811200"
+
+    [[ChainParams.TestNet3Params.Checkpoints]]
+      Height = 26115
+      Hash = [79, 193, 67, 91, 86, 166, 109, 219, 12, 114, 29, 2, 133, 186, 199, 187, 113, 146, 245, 226, 238, 82, 150, 67, 94, 171, 145, 158, 80, 91, 125, 129]
+
+    [[ChainParams.TestNet3Params.Checkpoints]]
+      Height = 43928
+      Hash = [180, 203, 147, 36, 129, 142, 20, 203, 48, 83, 52, 208, 13, 205, 72, 226, 35, 229, 138, 17, 131, 132, 135, 173, 246, 94, 63, 21, 76, 97, 134, 125]
+
+    [[ChainParams.TestNet3Params.Checkpoints]]
+      Height = 69296
+      Hash = [223, 16, 16, 119, 232, 103, 14, 131, 65, 244, 143, 26, 128, 24, 122, 125, 40, 245, 193, 9, 235, 85, 59, 9, 130, 210, 207, 163, 141, 245, 194, 102]
+
+    [[ChainParams.TestNet3Params.Checkpoints]]
+      Height = 99949
+      Hash = [222, 108, 252, 91, 17, 29, 128, 182, 113, 54, 217, 248, 96, 48, 118, 160, 121, 44, 147, 30, 75, 126, 30, 217, 234, 245, 236, 90, 203, 113, 212, 141]
+
+    [[ChainParams.TestNet3Params.Checkpoints]]
+      Height = 159256
+      Hash = [183, 178, 175, 20, 193, 245, 214, 37, 154, 149, 177, 100, 104, 96, 175, 41, 184, 109, 157, 17, 145, 69, 128, 20, 84, 47, 132, 104, 153, 11, 91, 171]
+
+    [[ChainParams.TestNet3Params.Deployments]]
+      BitNumber = 28
+      StartTime = 1199145601
+      ExpireTime = 1230767999
+
+    [[ChainParams.TestNet3Params.Deployments]]
+      BitNumber = 0
+      StartTime = 1483228800
+      ExpireTime = 1517356801
+
+    [[ChainParams.TestNet3Params.Deployments]]
+      BitNumber = 1
+      StartTime = 1483228800
+      ExpireTime = 1517356801
+  [ChainParams.RegressionNetParams]
+    Name = "regtest"
+    Net = 3669344250
+    DefaultPort = "18444"
+    DNSSeeds = []
+    GenesisHash = [6, 34, 110, 70, 17, 26, 11, 89, 202, 175, 18, 96, 67, 235, 91, 191, 40, 195, 79, 58, 94, 51, 42, 31, 199, 178, 183, 60, 241, 136, 145, 15]
+    PowLimitBits = 545259519
+    BIP0034Height = 100000000
+    BIP0065Height = 1351
+    BIP0066Height = 1251
+    CoinbaseMaturity = 100
+    SubsidyReductionInterval = 150
+    TargetTimespan = 1209600000000000
+    TargetTimePerBlock = 600000000000
+    RetargetAdjustmentFactor = 4
+    ReduceMinDifficulty = true
+    MinDiffReductionTime = 1200000000000
+    GenerateSupported = true
+    RuleChangeActivationThreshold = 108
+    MinerConfirmationWindow = 144
+    RelayNonStdTxs = true
+    Bech32HRPSegwit = "tltc"
+    PubKeyHashAddrID = 111
+    ScriptHashAddrID = 196
+    PrivateKeyID = 239
+    WitnessPubKeyHashAddrID = 0
+    WitnessScriptHashAddrID = 0
+    HDPrivateKeyID = [4, 53, 131, 148]
+    HDPublicKeyID = [4, 53, 135, 207]
+    HDCoinType = 1
+    [ChainParams.RegressionNetParams.GenesisBlock]
+      [ChainParams.RegressionNetParams.GenesisBlock.Header]
+        Version = 1
+        PrevBlock = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        MerkleRoot = [217, 206, 212, 237, 17, 48, 247, 183, 250, 173, 155, 226, 83, 35, 255, 175, 163, 50, 50, 161, 124, 62, 223, 108, 253, 151, 190, 230, 186, 251, 221, 151]
+        Timestamp = 2011-02-02T23:16:42Z
+        Bits = 545259519
+        Nonce = 2
+
+      [[ChainParams.RegressionNetParams.GenesisBlock.Transactions]]
+        Version = 1
+        LockTime = 0
+
+        [[ChainParams.RegressionNetParams.GenesisBlock.Transactions.TxIn]]
+          SignatureScript = [4, 255, 255, 0, 29, 1, 4, 64, 78, 89, 32, 84, 105, 109, 101, 115, 32, 48, 53, 47, 79, 99, 116, 47, 50, 48, 49, 49, 32, 83, 116, 101, 118, 101, 32, 74, 111, 98, 115, 44, 32, 65, 112, 112, 108, 101, 226, 128, 153, 115, 32, 86, 105, 115, 105, 111, 110, 97, 114, 121, 44, 32, 68, 105, 101, 115, 32, 97, 116, 32, 53, 54]
+          Sequence = 4294967295
+          [ChainParams.RegressionNetParams.GenesisBlock.Transactions.TxIn.PreviousOutPoint]
+            Hash = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            Index = 4294967295
+
+        [[ChainParams.RegressionNetParams.GenesisBlock.Transactions.TxOut]]
+          Value = 5000000000
+          PkScript = [65, 4, 1, 132, 113, 15, 166, 137, 173, 80, 35, 105, 12, 128, 243, 164, 156, 143, 19, 248, 212, 91, 140, 133, 127, 188, 188, 139, 196, 168, 228, 211, 235, 75, 16, 244, 212, 96, 79, 160, 141, 206, 96, 26, 175, 15, 71, 2, 22, 254, 27, 81, 133, 11, 74, 207, 33, 177, 121, 196, 80, 112, 172, 123, 3, 169, 172]
+    PowLimit = "57896044618658097711785492504343953926634992332820282019728792003956564819967"
+
+    [[ChainParams.RegressionNetParams.Deployments]]
+      BitNumber = 28
+      StartTime = 0
+      ExpireTime = 9223372036854775807
+
+    [[ChainParams.RegressionNetParams.Deployments]]
+      BitNumber = 0
+      StartTime = 0
+      ExpireTime = 9223372036854775807
+
+    [[ChainParams.RegressionNetParams.Deployments]]
+      BitNumber = 1
+      StartTime = 0
+      ExpireTime = 9223372036854775807
+  [ChainParams.SimNetParams]
+    Name = "simnet"
+    Net = 303307798
+    DefaultPort = "18555"
+    DNSSeeds = []
+    GenesisHash = [246, 122, 215, 105, 93, 155, 102, 42, 114, 255, 61, 142, 219, 187, 45, 224, 191, 166, 123, 19, 151, 75, 185, 145, 13, 17, 109, 92, 189, 134, 62, 104]
+    PowLimitBits = 545259519
+    BIP0034Height = 0
+    BIP0065Height = 0
+    BIP0066Height = 0
+    CoinbaseMaturity = 100
+    SubsidyReductionInterval = 210000
+    TargetTimespan = 1209600000000000
+    TargetTimePerBlock = 600000000000
+    RetargetAdjustmentFactor = 4
+    ReduceMinDifficulty = true
+    MinDiffReductionTime = 1200000000000
+    GenerateSupported = true
+    RuleChangeActivationThreshold = 75
+    MinerConfirmationWindow = 100
+    RelayNonStdTxs = true
+    Bech32HRPSegwit = "sltc"
+    PubKeyHashAddrID = 63
+    ScriptHashAddrID = 123
+    PrivateKeyID = 100
+    WitnessPubKeyHashAddrID = 25
+    WitnessScriptHashAddrID = 40
+    HDPrivateKeyID = [4, 32, 185, 0]
+    HDPublicKeyID = [4, 32, 189, 58]
+    HDCoinType = 115
+    [ChainParams.SimNetParams.GenesisBlock]
+      [ChainParams.SimNetParams.GenesisBlock.Header]
+        Version = 1
+        PrevBlock = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        MerkleRoot = [217, 206, 212, 237, 17, 48, 247, 183, 250, 173, 155, 226, 83, 35, 255, 175, 163, 50, 50, 161, 124, 62, 223, 108, 253, 151, 190, 230, 186, 251, 221, 151]
+        Timestamp = 2014-05-28T15:52:37Z
+        Bits = 545259519
+        Nonce = 2
+
+      [[ChainParams.SimNetParams.GenesisBlock.Transactions]]
+        Version = 1
+        LockTime = 0
+
+        [[ChainParams.SimNetParams.GenesisBlock.Transactions.TxIn]]
+          SignatureScript = [4, 255, 255, 0, 29, 1, 4, 64, 78, 89, 32, 84, 105, 109, 101, 115, 32, 48, 53, 47, 79, 99, 116, 47, 50, 48, 49, 49, 32, 83, 116, 101, 118, 101, 32, 74, 111, 98, 115, 44, 32, 65, 112, 112, 108, 101, 226, 128, 153, 115, 32, 86, 105, 115, 105, 111, 110, 97, 114, 121, 44, 32, 68, 105, 101, 115, 32, 97, 116, 32, 53, 54]
+          Sequence = 4294967295
+          [ChainParams.SimNetParams.GenesisBlock.Transactions.TxIn.PreviousOutPoint]
+            Hash = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            Index = 4294967295
+
+        [[ChainParams.SimNetParams.GenesisBlock.Transactions.TxOut]]
+          Value = 5000000000
+          PkScript = [65, 4, 1, 132, 113, 15, 166, 137, 173, 80, 35, 105, 12, 128, 243, 164, 156, 143, 19, 248, 212, 91, 140, 133, 127, 188, 188, 139, 196, 168, 228, 211, 235, 75, 16, 244, 212, 96, 79, 160, 141, 206, 96, 26, 175, 15, 71, 2, 22, 254, 27, 81, 133, 11, 74, 207, 33, 177, 121, 196, 80, 112, 172, 123, 3, 169, 172]
+    PowLimit = "57896044618658097711785492504343953926634992332820282019728792003956564819967"
+
+    [[ChainParams.SimNetParams.Deployments]]
+      BitNumber = 28
+      StartTime = 0
+      ExpireTime = 9223372036854775807
+
+    [[ChainParams.SimNetParams.Deployments]]
+      BitNumber = 0
+      StartTime = 0
+      ExpireTime = 9223372036854775807
+
+    [[ChainParams.SimNetParams.Deployments]]
+      BitNumber = 1
+      StartTime = 0
+      ExpireTime = 9223372036854775807


### PR DESCRIPTION
This adds a sample configuration file for `chaincfg` for the litecoin network