### PR TITLE
add PowLimit to ltcd config

### DIFF
--- a/sample-ltcd.conf
+++ b/sample-ltcd.conf
@@ -1,3 +1,7 @@
+[Wire]
+ProtocolVersion = 70013
+MainNet = 3686187259
+
 [ChainParams]
   [ChainParams.MainNetParams]
     Name = "mainnet"


### PR DESCRIPTION
this fixes a bug where PowLimit wasn't included in the ltc sample configs.

Which resulted in the following error.
```
2018-10-22 10:50:52.900 [INF] SYNC: Rejected block bc8f40c64a8fd1ddb9e5667590cc8b3be137e98079dfe7df59dfbf999276aefb from 52.76.154.206:9333 (outbound): block target difficulty of 00000ffff0000000000000000000000000000000000000000000000000000000 is higher than max of 00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
```